### PR TITLE
Integrate all

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,6 @@
 name: CMake
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,6 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [g++-10, clang]
+        include:
+          - compiler: clang
+            cxx_flags: -stdlib=libc++
+            # TODO figure why this is not set automatically
+            exe_linker_flags: -lc++
+          - compiler: g++-10
+            install: 'g++-10'
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +33,7 @@ jobs:
       run: sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
 
     - name: Install dependencies
-      run: sudo apt-get install g++-10
+      run: sudo apt-get install ${{ matrix.install }}
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -43,7 +50,12 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: |
+        cmake $GITHUB_WORKSPACE \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_CXX_FLAGS=${{ matrix.cxx_flags }} \
+          -DCMAKE_EXE_LINKER_FLAGS=${{ matrix.exe_linker_flags }} \
+          -DCMAKE_VERBOSE_MAKEFILE=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/cmake/FindCppcoroCoroutines.cmake
+++ b/cmake/FindCppcoroCoroutines.cmake
@@ -15,21 +15,6 @@ if(Coroutines_SUPPORTS_MS_FLAG)
 elseif(Coroutines_ts_SUPPORTS_GNU_FLAG)
     check_include_file_cxx("coroutine" Coroutines_STANDARD_LIBRARY_SUPPORT "-fcoroutines-ts")
     check_include_file_cxx("experimental/coroutine" Coroutines_EXPERIMENTAL_LIBRARY_SUPPORT "-fcoroutines-ts")
-    # workaround:
-    #  clang not find stdlibc++ headers when on ubuntu 20.04
-    #  So, we retry with libc++ enforcement
-    if(NOT Coroutines_STANDARD_LIBRARY_SUPPORT
-      AND NOT Coroutines_EXPERIMENTAL_LIBRARY_SUPPORT
-      AND CMAKE_CXX_COMPILER_ID MATCHES Clang)
-        set(CMAKE_REQUIRED_FLAGS "-stdlib=libc++")
-        check_include_file_cxx("coroutine" Coroutines_STANDARD_LIBRARY_SUPPORT_LIBCPP "-fcoroutines-ts")
-        check_include_file_cxx("experimental/coroutine" Coroutines_EXPERIMENTAL_LIBRARY_SUPPORT_LIBCPP "-fcoroutines-ts")
-        if(Coroutines_STANDARD_LIBRARY_SUPPORT_LIBCPP OR Coroutines_EXPERIMENTAL_LIBRARY_SUPPORT_LIBCPP)
-          list(APPEND Coroutines_EXTRA_FLAGS "-stdlib=libc++")
-          set(Coroutines_STANDARD_LIBRARY_SUPPORT ${Coroutines_STANDARD_LIBRARY_SUPPORT_LIBCPP})
-          set(Coroutines_EXPERIMENTAL_LIBRARY_SUPPORT ${Coroutines_EXPERIMENTAL_LIBRARY_SUPPORT_LIBCPP})
-        endif()
-    endif()
 elseif(Coroutines_SUPPORTS_GNU_FLAG)
     check_include_file_cxx("coroutine" Coroutines_STANDARD_LIBRARY_SUPPORT "-fcoroutines")
     check_include_file_cxx("experimental/coroutine" Coroutines_EXPERIMENTAL_LIBRARY_SUPPORT "-fcoroutines")

--- a/cmake/FindCppcoroCoroutines.cmake
+++ b/cmake/FindCppcoroCoroutines.cmake
@@ -40,5 +40,3 @@ elseif(Coroutines_ts_SUPPORTS_GNU_FLAG)
 elseif(Coroutines_SUPPORTS_GNU_FLAG)
     target_compile_options(cppcoro::coroutines INTERFACE -fcoroutines)
 endif()
-
-target_compile_options(cppcoro::coroutines INTERFACE ${Coroutines_EXTRA_FLAGS})

--- a/include/cppcoro/generator.hpp
+++ b/include/cppcoro/generator.hpp
@@ -32,8 +32,8 @@ namespace cppcoro
 
 			generator<T> get_return_object() noexcept;
 
-			constexpr cppcoro::suspend_always initial_suspend() const { return {}; }
-			constexpr cppcoro::suspend_always final_suspend() const { return {}; }
+			constexpr cppcoro::suspend_always initial_suspend() const noexcept { return {}; }
+			constexpr cppcoro::suspend_always final_suspend() const noexcept { return {}; }
 
 			template<
 				typename U = T,


### PR DESCRIPTION
Fixes clang build on github workflow

- add -lc++ to CMAKE_EXE_LINKER_FLAGS
- remove workaround in FindCppcoroCoroutine.cmake
- add `noexcept` specifier required by clang-12
