### PR TITLE
Unify experimental includes

### DIFF
--- a/include/cppcoro/coroutine.hpp
+++ b/include/cppcoro/coroutine.hpp
@@ -20,7 +20,10 @@ namespace cppcoro {
   using std::experimental::coroutine_handle;
   using std::experimental::suspend_always;
   using std::experimental::suspend_never;
-  using std::experimental::noop_coroutine;
+
+#if CPPCORO_COMPILER_SUPPORTS_SYMMETRIC_TRANSFER
+    using std::experimental::noop_coroutine;
+#endif
 }
 
 #else

--- a/include/cppcoro/detail/sync_wait_task.hpp
+++ b/include/cppcoro/detail/sync_wait_task.hpp
@@ -68,7 +68,7 @@ namespace cppcoro
 				return completion_notifier{};
 			}
 
-#if CPPCORO_COMPILER_MSVC
+#if CPPCORO_COMPILER_MSVC && CPPCORO_COMPILER_MSVC < 19'00'00000
 			// HACK: This is needed to work around a bug in MSVC 2017.7/2017.8.
 			// See comment in make_sync_wait_task below.
 			template<typename Awaitable>
@@ -245,7 +245,7 @@ namespace cppcoro
 
 		};
 
-#if CPPCORO_COMPILER_MSVC
+#if CPPCORO_COMPILER_MSVC && CPPCORO_COMPILER_MSVC < 19'00'00000
 		// HACK: Work around bug in MSVC where passing a parameter by universal reference
 		// results in an error when passed a move-only type, complaining that the copy-constructor
 		// has been deleted. The parameter should be passed by reference and the compiler should

--- a/include/cppcoro/detail/when_all_task.hpp
+++ b/include/cppcoro/detail/when_all_task.hpp
@@ -76,7 +76,7 @@ namespace cppcoro
 				assert(false);
 			}
 
-#if CPPCORO_COMPILER_MSVC
+#if CPPCORO_COMPILER_MSVC && CPPCORO_COMPILER_MSVC < 19'00'00000
 			// HACK: This is needed to work around a bug in MSVC 2017.7/2017.8.
 			// See comment in make_when_all_task below.
 			template<typename Awaitable>
@@ -301,7 +301,7 @@ namespace cppcoro
 			std::enable_if_t<!std::is_void_v<RESULT>, int> = 0>
 		when_all_task<RESULT> make_when_all_task(AWAITABLE awaitable)
 		{
-#if CPPCORO_COMPILER_MSVC
+#if CPPCORO_COMPILER_MSVC && CPPCORO_COMPILER_MSVC < 19'00'00000
 			// HACK: Workaround another bug in MSVC where the expression 'co_yield co_await x' seems
 			// to completely ignore the co_yield an never calls promise.yield_value().
 			// The coroutine seems to be resuming the 'co_await' after the 'co_yield'
@@ -329,7 +329,7 @@ namespace cppcoro
 			std::enable_if_t<!std::is_void_v<RESULT>, int> = 0>
 		when_all_task<RESULT> make_when_all_task(std::reference_wrapper<AWAITABLE> awaitable)
 		{
-#if CPPCORO_COMPILER_MSVC
+#if CPPCORO_COMPILER_MSVC && CPPCORO_COMPILER_MSVC < 19'00'00000
 			// HACK: Workaround another bug in MSVC where the expression 'co_yield co_await x' seems
 			// to completely ignore the co_yield and never calls promise.yield_value().
 			// The coroutine seems to be resuming the 'co_await' after the 'co_yield'

--- a/include/cppcoro/sync_wait.hpp
+++ b/include/cppcoro/sync_wait.hpp
@@ -18,7 +18,7 @@ namespace cppcoro
 	auto sync_wait(AWAITABLE&& awaitable)
 		-> typename cppcoro::awaitable_traits<AWAITABLE&&>::await_result_t
 	{
-#if CPPCORO_COMPILER_MSVC
+#if CPPCORO_COMPILER_MSVC && CPPCORO_COMPILER_MSVC < 19'00'00000
 		// HACK: Need to explicitly specify template argument to make_sync_wait_task
 		// here to work around a bug in MSVC when passing parameters by universal
 		// reference to a coroutine which causes the compiler to think it needs to


### PR DESCRIPTION
- fixes unknown noop_coroutine
- remove MSVC 2017 workarounds for MSVC >= 2019