### PR TITLE
removed "/await:heapelide"

### DIFF
--- a/config.cake
+++ b/config.cake
@@ -166,11 +166,6 @@ if cake.system.isWindows() or cake.system.isCygwin():
       compiler.addLibrary('ucrt')
       compiler.addLibrary('oldnames')
 
-      # Enable compiler to optimise-out heap allocations for coroutine frames
-      # Only supported on X64
-      if arch == 'x64':
-        compiler.addCppFlag('/await:heapelide')
-
       compiler.addDefine('NDEBUG')
 
       project = msvcOptVariant.tools["project"]


### PR DESCRIPTION
it doesn't have any official documentation (neither for VS 2015, 2017 or 2019!) and only seems to make trouble!