### PR TITLE
Default CMAKE_CXX_STANDARD to 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.12)
 project(cppcoro LANGUAGES CXX)
 
+if(NOT "${CMAKE_CXX_STANDARD}")
+  message("C++ version not set. Defaulting to CMAKE_CXX_STANDARD=20")
+  set(CMAKE_CXX_STANDARD 20)
+endif()
+
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
So far, the user was required to set the C++ version. It is required
that the user is able to select the version, as some users might want
to work with the C++17 coroutine-ts and others want to work with
C++20.
However, this led to frustration with many users, as just invoking
cmake did not lead to a working build. This patch changes the default
to C++20, informing the user about this choice.