### PR TITLE
Properly configure Coroutines cmake module

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -176,6 +176,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_CXX_STANDARD=${{ matrix.config.cxxver }} \
           -DBUILD_TESTING=ON \
+          -DCPPCORO_USAGE_TEST_DIR="${{runner.workspace}}/use_cppcoro" \
           -DCMAKE_CXX_FLAGS=${{ matrix.config.cxx_flags }} \
           -DCMAKE_EXE_LINKER_FLAGS=${{ matrix.config.exe_linker_flags }} \
           -DCMAKE_VERBOSE_MAKEFILE=ON

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,3 +60,72 @@ foreach(test ${tests})
 	endif()
 	doctest_discover_tests(${test_name} TEST_PREFIX ${test_prefix}- PROPERTIES TIMEOUT ${${test_name}_TIMEOUT})
 endforeach()
+
+function(add_usage_test variant_name cppcoro_ROOT)
+	set(APP_BINARY_DIR ${CPPCORO_USAGE_TEST_DIR}/app_build/${variant_name})
+	add_test(
+		NAME app_configure_${variant_name}
+		COMMAND
+			${CMAKE_COMMAND} 
+				-S ${CMAKE_CURRENT_LIST_DIR}/use_cppcoro
+				-B ${APP_BINARY_DIR}
+				-G ${CMAKE_GENERATOR}
+				-D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+				-D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+				-D CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+				-D cppcoro_ROOT=${cppcoro_ROOT}
+	)
+	add_test(
+		NAME app_build_${variant_name}
+		COMMAND
+			${CMAKE_COMMAND}
+				--build ${APP_BINARY_DIR}
+				--config ${CMAKE_BUILD_TYPE}
+	)
+	set_tests_properties(
+		app_configure_${variant_name}
+		PROPERTIES
+			FIXTURES_SETUP app_build_${variant_name}_requires
+			TIMEOUT 30
+	)
+	set_tests_properties(
+		app_build_${variant_name}
+		PROPERTIES
+			FIXTURES_REQUIRED app_build_${variant_name}_requires
+			TIMEOUT 30
+	)
+endfunction()
+
+if(CPPCORO_USAGE_TEST_DIR)
+	if(NOT IS_ABSOLUTE ${CPPCORO_USAGE_TEST_DIR})
+		set(CPPCORO_USAGE_TEST_DIR ${PROJECT_BINARY_DIR}/${CPPCORO_USAGE_TEST_DIR})
+	endif()
+
+	add_usage_test(with_cppcoro_build_tree ${PROJECT_BINARY_DIR})
+
+	if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
+		set(CPPCORO_USAGE_TEST_INSTALL_DIR ${CPPCORO_USAGE_TEST_DIR}/cppcoro_install)
+	
+		add_usage_test(with_cppcoro_install_dir ${CPPCORO_USAGE_TEST_INSTALL_DIR})
+	
+		add_test(
+			NAME cppcoro_usage_test_install
+			COMMAND
+				${CMAKE_COMMAND}
+					--install ${PROJECT_BINARY_DIR}
+					--config ${CMAKE_BUILD_TYPE}
+					--prefix ${CPPCORO_USAGE_TEST_INSTALL_DIR}
+		)
+		set_tests_properties(
+			cppcoro_usage_test_install
+			PROPERTIES
+				FIXTURES_SETUP app_configure_with_cppcoro_install_dir_requires
+				TIMEOUT 30
+		)
+		set_tests_properties(
+			app_configure_with_cppcoro_install_dir
+			PROPERTIES
+				FIXTURES_REQUIRED app_configure_with_cppcoro_install_dir_requires
+		)
+	endif()
+endif()

--- a/test/use_cppcoro/CMakeLists.txt
+++ b/test/use_cppcoro/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+project(use_cppcoro LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+find_package(cppcoro REQUIRED)
+
+add_executable(use_cppcoro use_cppcoro.cpp)
+target_link_libraries(use_cppcoro PRIVATE cppcoro::cppcoro)

--- a/test/use_cppcoro/use_cppcoro.cpp
+++ b/test/use_cppcoro/use_cppcoro.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+#include <cppcoro/generator.hpp>
+
+cppcoro::generator<int> sequence()
+{
+	co_yield 1;
+	co_yield 22;
+	co_yield 333;
+}
+
+int main()
+{
+	for (auto i : sequence())
+	{
+		std::cout << i << std::endl;
+	}
+}


### PR DESCRIPTION
There are some problems when using `cppcoro` from an external project:
- the installed library cannot be used if the final version of C++20 corouitines is not supported by toolset;
- the library cannot be used directly from its build tree, which would sometimes be convenient.

The first commit adds tests that attempt to build an executable using `cppcoro`:
- `app_build_with_cppcoro_install_dir`
- `app_build_with_cppcoro_build_tree`
- helper tests to install `cppcoro` and configure the application build tree.

Following commits make the tests successful.

This PR should probably go to `add_cmake_support`, but that branch looks somewhat outdated.