### PR TITLE
Fix MSVC compilation error

### DIFF
--- a/include/cppcoro/task.hpp
+++ b/include/cppcoro/task.hpp
@@ -49,7 +49,7 @@ namespace cppcoro
 				// were crashing under x86 optimised builds.
 				template<typename PROMISE>
 				CPPCORO_NOINLINE
-				void await_suspend(cppcoro::coroutine_handle<PROMISE> coroutine)
+				void await_suspend(cppcoro::coroutine_handle<PROMISE> coroutine) noexcept
 				{
 					task_promise_base& promise = coroutine.promise();
 


### PR DESCRIPTION
It looks like all the methods need to be `noexcept` for MSVC to accept `final_awaitable` being returned from a `noexcept` function. I don't know if the spec requires this, but it fixes the compilation error on My Machine:tm: