### PR TITLE
std::exchange needs #include <utility>

### DIFF
--- a/lib/static_thread_pool.cpp
+++ b/lib/static_thread_pool.cpp
@@ -12,6 +12,7 @@
 #include <cassert>
 #include <mutex>
 #include <chrono>
+#include <utility>
 
 namespace
 {


### PR DESCRIPTION
gcc 12 no longer includes \<utility\> when including \<chrono\>.

This means that the compilation under gcc 12 fails with this message:
```
~/cppcoro/lib/static_thread_pool.cpp: In member function ‘cppcoro::static_thread_pool::schedule_operation* cppcoro::static_thread_pool::try_global_dequeue()’:
~/cppcoro/lib/static_thread_pool.cpp:670:51: error: ‘exchange’ is not a member of ‘std’; did you mean ‘std::__atomic_impl::exchange’?
  670 |                                 auto* next = std::exchange(tail->m_next, head);
      |                                                   ^~~~~~~~
```

This pull request fixes it.