### PR TITLE
Fix CI for Microsoft Visual Studio 2019

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -95,14 +95,14 @@ jobs:
           }
           - {
             name: "Windows MSVC 2019 (x64) C++17",
-            os: windows-latest,
+            os: windows-2019,
             cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cxxver: 17,
           }
           - {
             name: "Windows MSVC 2019 (x64) C++20",
-            os: windows-latest,
+            os: windows-2019,
             cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
             cxxver: 20,

--- a/include/cppcoro/async_scope.hpp
+++ b/include/cppcoro/async_scope.hpp
@@ -86,7 +86,7 @@ namespace cppcoro
 			struct promise_type
 			{
 				cppcoro::suspend_never initial_suspend() { return {}; }
-				cppcoro::suspend_never final_suspend() { return {}; }
+				cppcoro::suspend_never final_suspend() noexcept { return {}; }
 				void unhandled_exception() { std::terminate(); }
 				oneway_task get_return_object() { return {}; }
 				void return_void() {}


### PR DESCRIPTION
The CI was using the image "windows-latest" to test with
MSVC 2019. However, windows-latest changed to MSVC 2022, so the CI
failed. This patch changes these configurations from
windows-latest to windows-2019.