### PR TITLE
Added linux scheduler

### DIFF
--- a/include/cppcoro/detail/linux.hpp
+++ b/include/cppcoro/detail/linux.hpp
@@ -1,0 +1,113 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Microsoft
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#ifndef CPPCORO_DETAIL_LINUX_HPP_INCLUDED
+#define CPPCORO_DETAIL_LINUX_HPP_INCLUDED
+
+#include <fcntl.h>
+#include <linux/limits.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+#include <utility>
+
+namespace cppcoro
+{
+	namespace detail
+	{
+		namespace linux
+		{
+			using fd_t = int;
+
+			enum message_type
+			{
+				CALLBACK_TYPE,
+				RESUME_TYPE
+			};
+
+			class safe_fd
+			{
+			public:
+				safe_fd()
+					: m_fd(-1)
+				{
+				}
+
+				explicit safe_fd(fd_t fd)
+					: m_fd(fd)
+				{
+				}
+
+				safe_fd(const safe_fd& other) = delete;
+
+				safe_fd(safe_fd&& other) noexcept
+					: m_fd(other.m_fd)
+				{
+					other.m_fd = -1;
+				}
+
+				~safe_fd() { close(); }
+
+				safe_fd& operator=(safe_fd fd) noexcept
+				{
+					swap(fd);
+					return *this;
+				}
+
+				constexpr fd_t fd() const { return m_fd; }
+
+				/// Calls close() and sets the fd to -1.
+				void close() noexcept;
+
+				void swap(safe_fd& other) noexcept { std::swap(m_fd, other.m_fd); }
+
+				bool operator==(const safe_fd& other) const { return m_fd == other.m_fd; }
+
+				bool operator!=(const safe_fd& other) const { return m_fd != other.m_fd; }
+
+				bool operator==(fd_t fd) const { return m_fd == fd; }
+
+				bool operator!=(fd_t fd) const { return m_fd != fd; }
+
+			private:
+				fd_t m_fd;
+			};
+
+			struct message
+			{
+				enum message_type m_type;
+				void* m_ptr;
+			};
+
+			struct io_state : linux::message
+			{
+				using callback_type = void(io_state* state);
+				callback_type* m_callback;
+			};
+
+			class message_queue
+			{
+			private:
+				int m_pipefd[2];
+				safe_fd m_epollfd;
+				struct epoll_event m_ev;
+
+			public:
+				message_queue();
+				~message_queue();
+				bool enqueue_message(void* message, message_type type);
+				bool dequeue_message(void*& message, message_type& type, bool wait);
+			};
+
+			safe_fd create_event_fd();
+			safe_fd create_timer_fd();
+			safe_fd create_epoll_fd();
+		}  // namespace linux
+	}      // namespace detail
+}  // namespace cppcoro
+
+#endif

--- a/include/cppcoro/io_service.hpp
+++ b/include/cppcoro/io_service.hpp
@@ -11,6 +11,8 @@
 
 #if CPPCORO_OS_WINNT
 # include <cppcoro/detail/win32.hpp>
+#elif CPPCORO_OS_LINUX
+# include <cppcoro/detail/linux.hpp>
 #endif
 
 #include <optional>
@@ -172,6 +174,9 @@ namespace cppcoro
 
 		std::atomic<bool> m_winsockInitialised;
 		std::mutex m_winsockInitialisationMutex;
+
+#elif CPPCORO_OS_LINUX
+ 		detail::linux::message_queue m_mq;
 #endif
 
 		// Head of a linked-list of schedule operations that are

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -156,6 +156,17 @@ if(WIN32)
       # TODO remove this when experimental/non-experimental include are fixed
       list(APPEND compile_definition _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING=1)
     endif()
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    set(linuxDetailIncludes
+        linux.hpp
+    )
+    list(TRANSFORM linuxDetailIncludes PREPEND "${PROJECT_SOURCE_DIR}/include/cppcoro/detail/")
+    list(APPEND detailIncludes ${linuxDetailIncludes})
+
+    list(APPEND sources
+        linux.cpp
+        io_service.cpp
+    )
 endif()
 
 add_library(cppcoro

--- a/lib/linux.cpp
+++ b/lib/linux.cpp
@@ -1,0 +1,172 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Microsoft
+// Licenced under MIT license. See LICENSE.txt for details.
+///////////////////////////////////////////////////////////////////////////////
+#include <cppcoro/detail/linux.hpp>
+#include <system_error>
+#include <unistd.h>
+#include <cstring>
+#include <cassert>
+
+namespace cppcoro
+{
+	namespace detail
+	{
+		namespace linux
+		{
+			message_queue::message_queue()
+			{
+				if (pipe2(m_pipefd, O_NONBLOCK) == -1) {
+					throw std::system_error
+					{
+						static_cast<int>(errno),
+						std::system_category(),
+						"Error creating io_service: failed creating pipe"
+					};
+				}
+				m_epollfd = safe_fd{create_epoll_fd()};
+				m_ev.data.fd = m_pipefd[0];
+				m_ev.events = EPOLLIN;
+
+				if(epoll_ctl(m_epollfd.fd(), EPOLL_CTL_ADD, m_pipefd[0], &m_ev) == -1)
+				{
+					throw std::system_error
+					{
+						static_cast<int>(errno),
+						std::system_category(),
+						"Error creating io_service: epoll ctl pipe"
+					};
+				}
+			}
+
+			message_queue::~message_queue()
+			{
+				assert(close(m_pipefd[0]) == 0);
+				assert(close(m_pipefd[1]) == 0);
+			}
+
+			bool message_queue::enqueue_message(void* msg, message_type type)
+			{
+				message qmsg;
+				qmsg.m_type = type;
+				qmsg.m_ptr = msg;
+				int status = write(m_pipefd[1], (const char*)&qmsg, sizeof(message));
+				return status==-1?false:true;
+			}
+
+			bool message_queue::dequeue_message(void*& msg, message_type& type, bool wait)
+			{
+				struct epoll_event ev = {0};
+				int nfds = epoll_wait(m_epollfd.fd(), &ev, 1, wait?-1:0);
+
+				if(nfds == -1)
+				{
+					if (errno == EINTR || errno == EAGAIN) {
+						return false;
+					}
+					throw std::system_error
+					{
+						static_cast<int>(errno),
+						std::system_category(),
+						"Error in epoll_wait run loop"
+					};
+				}
+
+				if(nfds == 0 && !wait)
+				{
+					return false;
+				}
+
+				if(nfds == 0 && wait)
+				{
+					throw std::system_error
+					{
+						static_cast<int>(errno),
+						std::system_category(),
+						"Error in epoll_wait run loop"
+					};
+				}
+
+				message qmsg;
+				ssize_t status = read(m_pipefd[0], (char*)&qmsg, sizeof(message));
+
+				if(status == -1)
+				{
+					if (errno == EINTR || errno == EAGAIN) {
+						return false;
+					}
+					throw std::system_error
+					{
+						static_cast<int>(errno),
+						std::system_category(),
+						"Error retrieving message from message queue: mq_receive"
+					};
+				}
+
+				msg = qmsg.m_ptr;
+				type = qmsg.m_type;
+				return true;
+			}
+
+			safe_fd create_event_fd()
+			{
+				int fd = eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK | EFD_CLOEXEC);
+
+				if(fd == -1)
+				{
+					throw std::system_error
+					{
+						static_cast<int>(errno),
+						std::system_category(),
+						"Error creating io_service: event fd create"
+					};
+				}
+
+				return safe_fd{fd};
+			}
+
+			safe_fd create_timer_fd()
+			{
+				int fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+
+				if(fd == -1)
+				{
+					throw std::system_error
+					{
+						static_cast<int>(errno),
+						std::system_category(),
+						"Error creating io_service: timer fd create"
+					};
+				}
+
+				return safe_fd{fd};
+			}
+
+			safe_fd create_epoll_fd()
+			{
+				int fd = epoll_create1(EPOLL_CLOEXEC);
+
+				if(fd == -1)
+				{
+					throw std::system_error
+					{
+						static_cast<int>(errno),
+						std::system_category(),
+						"Error creating timer thread: epoll create"
+					};
+				}
+
+				return safe_fd{fd};
+			}
+
+			void safe_fd::close() noexcept
+			{
+				if(m_fd != -1)
+				{
+					::close(m_fd);
+					m_fd = -1;
+				}
+			}
+		}
+	}
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,12 @@ if(WIN32)
         socket_tests.cpp
     )
 else()
+	if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+		list(APPEND tests
+			scheduling_operator_tests.cpp
+			io_service_tests.cpp
+		)
+	endif()
 	# let more time for some tests
 	set(async_auto_reset_event_tests_TIMEOUT 60)
 endif()


### PR DESCRIPTION
This is mostly based on https://github.com/lewissbaker/cppcoro/pull/64
I changed the message queue implementation from mqeueue to a simple pipe().
It's mainly just a simplification, none of the mqueue specific features were being used and the code had needless complexity. (such as dependency on libuuid).
I saw the other proposals using io_uring and decided against it as it only supports new-ish kernels.
Epoll would support many more kernel versions.
Also, supporting kqueue for macOS would be super simple as it is almost identical to epoll in terms of usage.