### PR TITLE
added default initializer for pointers in generator.hpp

### DIFF
--- a/include/cppcoro/generator.hpp
+++ b/include/cppcoro/generator.hpp
@@ -78,8 +78,8 @@ namespace cppcoro
 
 		private:
 
-			pointer_type m_value;
-			std::exception_ptr m_exception;
+			pointer_type m_value{};
+			std::exception_ptr m_exception{};
 
 		};
 


### PR DESCRIPTION
trying to make shure all primitives (in this case pointers) are initialized with some defined values