### PR TITLE
Avoid redefining `WIN32_LEAN_AND_MEAN` on Windows

### DIFF
--- a/lib/auto_reset_event.cpp
+++ b/lib/auto_reset_event.cpp
@@ -6,7 +6,9 @@
 #include "auto_reset_event.hpp"
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <windows.h>
 # include <system_error>
 #endif

--- a/lib/spin_wait.cpp
+++ b/lib/spin_wait.cpp
@@ -9,7 +9,9 @@
 #include <thread>
 
 #if CPPCORO_OS_WINNT
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # include <windows.h>
 #endif
 


### PR DESCRIPTION
This causes warnings for people integrating cppcoro's sources in their projects without using your CMakeLists.

Other files already do the #ifndef check.

Thanks.