### PR TITLE
Include `<chrono>` for `high_resolution_clock`

### DIFF
--- a/test/cancellation_token_tests.cpp
+++ b/test/cancellation_token_tests.cpp
@@ -8,6 +8,7 @@
 #include <cppcoro/cancellation_registration.hpp>
 #include <cppcoro/operation_cancelled.hpp>
 
+#include <chrono>
 #include <thread>
 
 #include <ostream>


### PR DESCRIPTION
I work on Microsoft Visual C++, where we regularly build popular open-source projects, including yours, with development builds of our compiler and libraries to detect and prevent shipping regressions that would affect you. This also allows us to provide advance notice of breaking changes, which is the case here.

I just merged https://github.com/microsoft/STL/pull/5105, which revealed a conformance issue in cppcoro.

Compiler error with this STL change:

```
C:\gitP\andreasbuhr\cppcoro\test\cancellation_token_tests.cpp(294,28): error C3083: 'high_resolution_clock': the symbol to the left of a '::' must be a type
```

Affected code:
https://github.com/andreasbuhr/cppcoro/blob/a4ef65281814b18fdd1ac5457d3e219347ec6cb8/test/cancellation_token_tests.cpp#L294

This was assuming that including `<thread>` makes the `chrono::high_resolution_clock` type available, which is not guaranteed by the Standard. You must explicitly include `<chrono>`.