### PR TITLE
Support C++20, replace implicit capture of this with explicit captures

### DIFF
--- a/lib/file_read_operation.cpp
+++ b/lib/file_read_operation.cpp
@@ -60,7 +60,7 @@ bool cppcoro::file_read_operation_impl::try_start(
 		operation.m_res = -errno;
 		return false;
 	}
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, this]() {
 		int res = read(m_fd, m_buffer, m_byteCount);
 		operation.m_mq->remove_fd_watch(m_fd);
 		return res;

--- a/lib/file_write_operation.cpp
+++ b/lib/file_write_operation.cpp
@@ -60,7 +60,7 @@ bool cppcoro::file_write_operation_impl::try_start(
 		operation.m_res = -errno;
 		return false;
 	}
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, this]() {
 		int res = write(m_fd, m_buffer, m_byteCount);
 		operation.m_mq->remove_fd_watch(m_fd);
 		return res;

--- a/lib/socket_accept_operation.cpp
+++ b/lib/socket_accept_operation.cpp
@@ -138,7 +138,7 @@ bool cppcoro::net::socket_accept_operation_impl::try_start(
 		(sizeof(m_addressBuffer) / 2) >= (16 + sizeof(sockaddr_in6)),
 		"AcceptEx requires address buffer to be at least 16 bytes more than largest address.");
 
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, this]() {
 		socklen_t len = sizeof(m_addressBuffer) / 2;
 		int res = accept(m_listeningSocket.native_handle(), reinterpret_cast<sockaddr*>(m_addressBuffer), &len);
 		operation.m_mq->remove_fd_watch(m_listeningSocket.native_handle());

--- a/lib/socket_connect_operation.cpp
+++ b/lib/socket_connect_operation.cpp
@@ -194,7 +194,7 @@ bool cppcoro::net::socket_connect_operation_impl::try_start(
 		operation.m_res = -errno;
 		return false;
 	}
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, remoteSockaddrStorage, sockaddrNameLength, this]() {
 		int res = connect(m_socket.native_handle(), reinterpret_cast<const sockaddr*>(&remoteSockaddrStorage), sockaddrNameLength);
 		operation.m_mq->remove_fd_watch(m_socket.native_handle());
 		return res;

--- a/lib/socket_disconnect_operation.cpp
+++ b/lib/socket_disconnect_operation.cpp
@@ -112,7 +112,7 @@ void cppcoro::net::socket_disconnect_operation_impl::get_result(
 bool cppcoro::net::socket_disconnect_operation_impl::try_start(
 	cppcoro::detail::linux_async_operation_base& operation) noexcept
 {
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, this]() {
 		operation.m_mq->remove_fd_watch(m_socket.native_handle());
 		int res = m_socket.close();
 		return res;

--- a/lib/socket_recv_from_operation.cpp
+++ b/lib/socket_recv_from_operation.cpp
@@ -109,7 +109,7 @@ bool cppcoro::net::socket_recv_from_operation_impl::try_start(
 		sockaddrStorageAlignment >= alignof(sockaddr_in6));
 	m_sourceSockaddrLength = sizeof(m_sourceSockaddrStorage);
 
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, this]() {
 		int res = recvfrom(
 			m_socket.native_handle(), m_buffer, m_byteCount, MSG_TRUNC,
 			reinterpret_cast<sockaddr*>(&m_sourceSockaddrStorage),

--- a/lib/socket_recv_operation.cpp
+++ b/lib/socket_recv_operation.cpp
@@ -72,7 +72,7 @@ void cppcoro::net::socket_recv_operation_impl::cancel(
 bool cppcoro::net::socket_recv_operation_impl::try_start(
 	cppcoro::detail::linux_async_operation_base& operation) noexcept
 {
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, this]() {
 		int res = recv(m_socket.native_handle(), m_buffer, m_byteCount, 0);
 		operation.m_mq->remove_fd_watch(m_socket.native_handle());
 		return res;

--- a/lib/socket_send_operation.cpp
+++ b/lib/socket_send_operation.cpp
@@ -69,7 +69,7 @@ void cppcoro::net::socket_send_operation_impl::cancel(
 bool cppcoro::net::socket_send_operation_impl::try_start(
 	cppcoro::detail::linux_async_operation_base& operation) noexcept
 {
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, this]() {
 		int res = send(m_socket.native_handle(), m_buffer, m_byteCount, 0);
 		operation.m_mq->remove_fd_watch(m_socket.native_handle());
 		return res;

--- a/lib/socket_send_to_operation.cpp
+++ b/lib/socket_send_to_operation.cpp
@@ -81,7 +81,7 @@ bool cppcoro::net::socket_send_to_operation_impl::try_start(
 	sockaddr_storage destinationAddress = {0};
 	const socklen_t destinationLength = detail::ip_endpoint_to_sockaddr(
 		m_destination, std::ref(destinationAddress));
-	operation.m_completeFunc = [=]() {
+	operation.m_completeFunc = [operation, this]() {
 		int res = sendto(
 			m_socket.native_handle(), m_buffer, m_byteCount, 0,
 			reinterpret_cast<const sockaddr*>(&destinationAddress),

--- a/lib/socket_send_to_operation.cpp
+++ b/lib/socket_send_to_operation.cpp
@@ -81,7 +81,7 @@ bool cppcoro::net::socket_send_to_operation_impl::try_start(
 	sockaddr_storage destinationAddress = {0};
 	const socklen_t destinationLength = detail::ip_endpoint_to_sockaddr(
 		m_destination, std::ref(destinationAddress));
-	operation.m_completeFunc = [operation, this]() {
+	operation.m_completeFunc = [operation, destinationAddress, destinationLength, this]() {
 		int res = sendto(
 			m_socket.native_handle(), m_buffer, m_byteCount, 0,
 			reinterpret_cast<const sockaddr*>(&destinationAddress),


### PR DESCRIPTION
C++20 deprecated the implicit capture of this for lambda captures.

This PR replaces all implicit captures by value `[=]`, with their explicit equivalents.