### PR TITLE
Revert "Use llvm installation script from GitHub"

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -540,7 +540,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.HOME }}
       run: |
-        wget https://raw.githubusercontent.com/opencollab/llvm-jenkins.debian.net/refs/heads/master/llvm.sh
+        wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh 22
         sudo apt-get install libc++-22-dev libc++abi-22-dev libunwind-22-dev


### PR DESCRIPTION
This reverts commit a91308e04af636d430d18cf3913a4cc47d2c5660. It is not needed any more, because the bug in the installation file was fixed, see https://github.com/llvm/llvm-project/issues/183715